### PR TITLE
Fix license owner name

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 APM30
+Copyright (c) 2025 BYC30
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary
- update MIT license header to reflect correct owner name

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_683d6f3a9d688326824c8210494e395f