### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/release-extension.yml
+++ b/.github/workflows/release-extension.yml
@@ -1,0 +1,50 @@
+name: Build and Release Chrome Extension
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_version:
+        description: 'Release version (e.g. v1.0.0)'
+        required: true
+        default: 'v0.1.0'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Create release branch
+        run: |
+          BRANCH="release-${{ github.event.inputs.release_version }}"
+          git checkout -b "$BRANCH"
+          git push origin "$BRANCH"
+          echo "BRANCH=$BRANCH" >> $GITHUB_ENV
+
+      - name: Package Chrome extension
+        run: |
+          cd src
+          zip -r ../OrinTabs.zip .
+          cd ..
+
+      - name: Create GitHub release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.event.inputs.release_version }}
+          release_name: Release ${{ github.event.inputs.release_version }}
+          draft: false
+          prerelease: false
+
+      - name: Upload release asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./OrinTabs.zip
+          asset_name: OrinTabs.zip
+          asset_content_type: application/zip

--- a/README.md
+++ b/README.md
@@ -40,6 +40,13 @@ OrinTabs (设想中) 会在本地或通过安全的 API 与一个大型语言模
 4.  使用顶部的搜索框进行自然语言搜索。
 5.  右键点击标签页或分组以获取更多选项 (例如，摘要、添加到工作区)。
 
+## 🔄 自动发布 (Automated Release)
+本仓库提供 `Build and Release Chrome Extension` 的 GitHub Actions 工作流。
+
+在 GitHub 的 **Actions** 选项卡中手动触发该流程，并填写发布版本号后，
+它会创建 `release-{version}` 分支并打包 `src` 目录生成 `OrinTabs.zip`，
+随后将这个压缩包上传到新的 Release 中。
+
 
 ## 💡 未来规划 (Roadmap)
 


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build and release Chrome extension
- document the manual release workflow in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_683d72e49be083269f450f8a01fc7de4