### PR TITLE
Improve popup interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 *   **重复标签检测 (Duplicate Tab Detection):** 智能识别并帮助您管理重复打开的标签页。
 *   **工作区管理 (Workspace Management):** 基于项目、任务或主题创建和切换不同的标签页工作区。
 *   **自然语言命令 (Natural Language Commands):** (未来规划) 通过简单的自然语言指令管理标签，例如“关闭所有购物相关的标签”。
+*   **可选暗黑模式 (Optional Dark Mode):** 弹出页支持暗黑主题，并在界面上显示当前窗口的标签和分组数量。
 
 ## 🤔 为何选择 OrinTabs? (Why OrinTabs?)
 

--- a/src/popup.html
+++ b/src/popup.html
@@ -8,11 +8,17 @@
     button { width: 100%; padding: 8px; margin-top: 6px; }
     input { width: 100%; box-sizing: border-box; margin-top: 4px; }
     label { font-size: 12px; }
+    #stats { font-size: 12px; margin-top: 8px; text-align: center; }
+    body.dark { background-color: #333; color: #eee; }
+    body.dark button { background-color: #555; color: #eee; }
+    body.dark input { background-color: #444; color: #eee; border: 1px solid #666; }
   </style>
 </head>
 <body>
   <button id="group-btn">Intelligent Group</button>
   <button id="summarize-btn">Summarize & Group</button>
+  <div id="stats"></div>
+  <button id="toggle-theme-btn">Toggle Dark Mode</button>
   <hr/>
   <label for="api-url">LLM API URL</label>
   <input id="api-url" type="text" placeholder="https://api.openai.com/v1/chat/completions" />

--- a/src/popup.js
+++ b/src/popup.js
@@ -10,10 +10,25 @@ document.getElementById('summarize-btn').addEventListener('click', () => {
   });
 });
 
+function applyTheme(theme) {
+  document.body.classList.toggle('dark', theme === 'dark');
+}
+
+function updateStats() {
+  chrome.tabs.query({currentWindow: true}, (tabs) => {
+    chrome.tabGroups.query({windowId: chrome.windows.WINDOW_ID_CURRENT}, (groups) => {
+      const statsEl = document.getElementById('stats');
+      statsEl.textContent = `Tabs: ${tabs.length}, Groups: ${groups.length}`;
+    });
+  });
+}
+
 document.addEventListener('DOMContentLoaded', () => {
-  chrome.storage.local.get(['apiKey', 'apiUrl'], (result) => {
+  chrome.storage.local.get(['apiKey', 'apiUrl', 'theme'], (result) => {
     document.getElementById('api-key').value = result.apiKey || '';
     document.getElementById('api-url').value = result.apiUrl || 'https://api.openai.com/v1/chat/completions';
+    applyTheme(result.theme || 'light');
+    updateStats();
   });
 });
 
@@ -22,5 +37,12 @@ document.getElementById('save-config-btn').addEventListener('click', () => {
   const apiUrl = document.getElementById('api-url').value;
   chrome.storage.local.set({apiKey, apiUrl}, () => {
     window.close();
+  });
+});
+
+document.getElementById('toggle-theme-btn').addEventListener('click', () => {
+  chrome.storage.local.get('theme', ({theme}) => {
+    const newTheme = theme === 'dark' ? 'light' : 'dark';
+    chrome.storage.local.set({theme: newTheme}, () => applyTheme(newTheme));
   });
 });


### PR DESCRIPTION
## Summary
- add dark mode styles and stats in popup
- show window stats and allow theme toggle
- document new optional dark mode feature

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_683d9a267b4083269786914dfba50b98