### PR TITLE
Remove duplicate release section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,14 +54,6 @@ OrinTabs (设想中) 会在本地或通过安全的 API 与一个大型语言模
 它会创建 `release-{version}` 分支并打包 `src` 目录生成 `OrinTabs.zip`，
 随后将这个压缩包上传到新的 Release 中。
 
-## 🔄 自动发布 (Automated Release)
-本仓库提供 `Build and Release Chrome Extension` 的 GitHub Actions 工作流。
-
-在 GitHub 的 **Actions** 选项卡中手动触发该流程，并填写发布版本号后，
-它会创建 `release-{version}` 分支并打包 `src` 目录生成 `OrinTabs.zip`，
-随后将这个压缩包上传到新的 Release 中。
-
-
 ## 💡 未来规划 (Roadmap)
 
 *   [ ] **更高级的 LLM 集成:** 例如，基于标签页内容的问答。


### PR DESCRIPTION
## Summary
- keep a single "🔄 自动发布" section in the README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_683da0fda36483268bbd4a215e805183